### PR TITLE
Allowed and disallowed file names

### DIFF
--- a/src/wikmd/utils.py
+++ b/src/wikmd/utils.py
@@ -1,6 +1,8 @@
 import os
 import unicodedata
+import re
 
+_filename_ascii_strip_re = re.compile(r"[^A-Za-z0-9 _.-]")
 _windows_device_files = {
     "CON",
     "PRN",
@@ -21,7 +23,9 @@ def secure_filename(filename: str) -> str:
     for sep in os.sep, os.path.altsep:
         if sep:
             filename = filename.replace(sep, "_")
-    filename = filename.strip("._")
+    filename = str(_filename_ascii_strip_re.sub("", filename)).strip(
+        "._"
+    )
     # on nt a couple of special files are present in each folder.  We
     # have to ensure that the target file is not such a filename.  In
     # this case we prepend an underline
@@ -33,6 +37,7 @@ def secure_filename(filename: str) -> str:
         filename = f"_{filename}"
 
     return filename
+
 
 def pathify(path1, path2):
     """

--- a/src/wikmd/wiki.py
+++ b/src/wikmd/wiki.py
@@ -96,23 +96,27 @@ def process(content: str, page_name: str):
 
 def ensure_page_can_be_created(page, page_name):
     filename = safe_join(cfg.wiki_directory, f"{page_name}.md")
-    path_exists = os.path.exists(filename)
-    safe_name = "/".join([secure_filename(part) for part in page_name.split("/")])
-    filename_is_ok = safe_name == page_name
-    if not path_exists and filename_is_ok and page_name:  # Early exist
-        return
-
-    if path_exists:
-        flash('A page with that name already exists. The page name needs to be unique.')
-        app.logger.info(f"Page name exists >>> {page_name}.")
-
-    if not filename_is_ok:
-        flash(f"Page name not accepted. Try using '{safe_name}'.")
+    if filename is None:
+        flash(f"Page name not accepted. Contains disallowed characters.")
         app.logger.info(f"Page name isn't secure >>> {page_name}.")
+    else:
+        path_exists = os.path.exists(filename)
+        safe_name = "/".join([secure_filename(part) for part in page_name.split("/")])
+        filename_is_ok = safe_name == page_name
+        if not path_exists and filename_is_ok and page_name:  # Early exist
+            return
 
-    if not page_name:
-        flash(f"Your page needs a name.")
-        app.logger.info(f"No page name provided.")
+        if path_exists:
+            flash('A page with that name already exists. The page name needs to be unique.')
+            app.logger.info(f"Page name exists >>> {page_name}.")
+
+        if not filename_is_ok:
+            flash(f"Page name not accepted. Try using '{safe_name}'.")
+            app.logger.info(f"Page name isn't secure >>> {page_name}.")
+
+        if not page_name:
+            flash(f"Your page needs a name.")
+            app.logger.info(f"No page name provided.")
 
     content = process(request.form['CT'], page_name)
     return render_template("new.html", content=content, title=page, upload_path=cfg.images_route,


### PR DESCRIPTION
### Summary
The rules to which file names were allowed was too wide.
This fixes that as well as adds tests to make sure it doesn't break again.
