### PR TITLE
Use uri for search

### DIFF
--- a/src/wikmd/templates/base.html
+++ b/src/wikmd/templates/base.html
@@ -44,7 +44,7 @@
             </button>
 
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
-                <form class="d-flex my-sm-4 my-lg-0 ms-lg-4" method="GET" action="/">
+                <form class="d-flex my-sm-4 my-lg-0 ms-lg-4" method="GET" action="{{ url_for('search_route') }}">
                     <input class="form-control me-2" type="search" placeholder="Search something..." aria-label="Search" name="q">
                     <button class="btn btn-primary me-2" type="submit">
                         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-search">

--- a/src/wikmd/templates/search.html
+++ b/src/wikmd/templates/search.html
@@ -63,7 +63,7 @@
     <p>
         Did you mean?: 
         {% for term in suggestions %}
-            <a href="/?q={{ term }}">{{ term }}</a>
+            <a href="{{ url_for('search_route') }}?q={{ term }}">{{ term }}</a>
         {% if not loop.last %}, {% endif %}
     {% endfor %}
     <ul id="list">
@@ -78,7 +78,7 @@
         <ul class="pagination">
         {% for page in range(1, num_pages + 1) %}
             <li class="pagination">
-                <a href="/?q={{ search_term }}&page={{ page }}" {% if page == current_page %} class="active" {% endif %}>{{ page }}</a>
+                <a href="{{ url_for('search_route') }}?q={{ search_term }}&page={{ page }}" {% if page == current_page %} class="active" {% endif %}>{{ page }}</a>
             </li>
         {% endfor %}
         <ul>

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -78,7 +78,7 @@ def test_create_file_in_folder(wiki_file, test_file_content):
 def test_search():
     """Search functionality returns result."""
     wiki.setup_search()
-    rv = app.test_client().get("/?q=Features")
+    rv = app.test_client().get("/search?q=Features")
     assert rv.status_code == 200
     assert b"Found" in rv.data
     assert b"result(s)" in rv.data


### PR DESCRIPTION
### Summary
Searches is now done at a `/search?=` url

### Details
Uses a standard convention uri for searching
This simplifies some other routes because now we don't have to guard or double check that they are not searches.
